### PR TITLE
Introduce state setting and rename StatStore object to EdgeState

### DIFF
--- a/src/edge_conf
+++ b/src/edge_conf
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+"""
+Tool for manipulating the state of edges.
+
+  edge_conf takes the required mode parameter and sets the mode of an
+ edge to the corresponding mode. The behaviours of these modes can be
+ seen in edgemanage/const.py.
+
+"""
+
+__author__="nosmo@nosmo.me"
+
+from edgemanage import EdgeState
+from edgemanage.const import VALID_MODES, CONFIG_PATH
+
+import argparse
+import os
+
+import yaml
+
+def main(dnet, edgename, config, mode):
+
+    with open(os.path.join(config["edgelist_dir"], dnet)) as edge_f:
+        edge_list = [ i.strip() for i in edge_f.read().split("\n") if i.strip() and not i.startswith("#") ]
+
+    if edgename not in edge_list:
+        raise KeyError("Edge %s is not in the edge list of %s" % (edgename, dnet))
+
+    if not os.path.exists(os.path.join(config["healthdata_store"], "%s.edgestore" % edgename)):
+        raise Exception("Edge %s is not initialised yet - not setting status" % edgename)
+
+    edge_state = EdgeState(edgename, config["healthdata_store"], nowrite=False)
+    edge_state.set_mode(mode)
+    print "Set mode for %s to %s" % (edgename, mode)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Configure Deflect edge mode.')
+    parser.add_argument("--config", "-c", dest="config_path", action="store",
+                        help="Path to configuration file (defaults to %s)" % CONFIG_PATH,
+                        default=CONFIG_PATH)
+    parser.add_argument("--dnet", "-A", dest="dnet", action="store",
+                        help="Specify DNET (mandatory)")
+    parser.add_argument("--edge", "-E", dest="edge", action="store",
+                        help="Specify edge")
+    parser.add_argument("--mode", "-m", dest="mode", action="store", default=None,
+                        help="Set mode", required=True,
+                        choices=VALID_MODES)
+    parser.add_argument("edge", action="store",
+                        help="Edge to configure", nargs=1)
+    args = parser.parse_args()
+
+    if not args.dnet and not args.edge:
+        raise Exception("Arguments must specify either a DNET or a specific edge")
+
+    with open(args.config_path) as config_f:
+        config = yaml.safe_load(config_f.read())
+
+    main(args.dnet, args.edge[0], config, args.mode)

--- a/src/edge_manage
+++ b/src/edge_manage
@@ -35,7 +35,8 @@ def check_last_live(state_obj, decision_obj):
     still_healthy = []
 
     if state_obj.last_live:
-        logging.debug("Live edge list from previous run is %s", state_obj.last_live)
+        logging.debug("Live edge list from previous run is %s",
+                      state_obj.last_live)
 
     # Make sure that any edges that were in rotation are still
     # in a passing state. Discard any that are failing checks.
@@ -43,10 +44,15 @@ def check_last_live(state_obj, decision_obj):
         if oldlive_edge in decision_obj.current_judgement and \
            decision_obj.current_judgement[oldlive_edge] == "pass":
             still_healthy.append(oldlive_edge)
+        elif oldlive_edge not in decision_obj.current_judgement:
+            logging.warning(("Discarding previously live edge %s "
+                             "because it is no longer being checked",),
+                            oldlive_edge)
         else:
-            logging.debug("Discarding previously live edge %s because it is in state %s",
-                          oldlive_edge,
-                          decision_obj.current_judgement[oldlive_edge])
+            logging.debug(
+                "Discarding previously live edge %s because it is in state %s",
+                oldlive_edge,
+                decision_obj.current_judgement[oldlive_edge])
 
     return list(set(still_healthy))
 
@@ -160,7 +166,14 @@ def main(dnet, dry_run, config, state_obj):
         edge_states[edge].add_value(value)
         logging.info("Fetch time for %s: %f avg: %f",
                      edge, value, edge_states[edge].current_average())
-        decision.add_stat_store(edge_states[edge])
+
+        # Skip edges that we have forced out of commission
+        if edge_states[edge].mode == "unavailable":
+            logging.debug("Skipping edge %s as its status has been set to unavailable", edge)
+        else:
+            # otherwise add it to the decision maker
+            decision.add_edge_state(edge_states[edge])
+
     threshold_stats = decision.check_threshold(config["goodenough"])
     state_obj.verification_failures = verification_failues
     logging.debug("Stats of threshold check are %s", str(threshold_stats))
@@ -205,11 +218,6 @@ def main(dnet, dry_run, config, state_obj):
         logging.info("Successfully established %d edges: %s",
                      edgelist.get_live_count(), edgelist.get_live_edges())
 
-        # Note in the statefile that this edge has been put into rotation
-        for live_edge in edgelist.get_live_edges():
-            edge_states[live_edge].add_rotation()
-            edge_states[live_edge].set_state("in")
-
         # Iterate over every *zone file in the zonetemplate dir and write out files.
         for zonefile in glob.glob("%s/%s/*.zone" % (config["zonetemplate_dir"], dnet)):
             zone_name = zonefile.split(".zone")[0].split("/")[-1]
@@ -248,6 +256,17 @@ def main(dnet, dry_run, config, state_obj):
                       edgelist.get_live_count(), edgelist.get_live_edges(), config["edge_count"])
         state_obj.add_rotation(const.STATE_HISTORICAL_ROTATIONS)
         state_obj.last_live = edgelist.get_live_edges()
+
+    # We've got our edges, one way or another - let's set their states
+
+    # Note in the statefile that this edge has been put into rotation
+    for live_edge in edgelist.get_live_edges():
+        edge_states[live_edge].add_rotation()
+        edge_states[live_edge].set_state("in")
+
+    # Note that the remaining edges aren't in rotation
+    for unlive_edge in edgelist.get_unlive_edges():
+        edge_states[live_edge].set_state("out")
 
     if "commands" in config and "run_after" in config["commands"]:
         if config["commands"]["run_after"]:

--- a/src/edge_manage
+++ b/src/edge_manage
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from edgemanage import const, EdgeTest, StatStore, DecisionMaker, StateFile, EdgeList, VerifyFailed
+from edgemanage import const, EdgeTest, EdgeState, DecisionMaker, StateFile, EdgeList, VerifyFailed
 
 from concurrent.futures import ProcessPoolExecutor, as_completed
 import argparse
@@ -145,7 +145,7 @@ def main(dnet, dry_run, config, state_obj):
         if value == False:
             verification_failues.append(edge)
 
-        stat_store = StatStore(edge, config["healthdata_store"], nowrite=dry_run)
+        stat_store = EdgeState(edge, config["healthdata_store"], nowrite=dry_run)
         stat_stores[edge] = stat_store
         stat_store.add_value(value)
         logging.info("Fetch time for %s: %f avg: %f",

--- a/src/edge_manage
+++ b/src/edge_manage
@@ -18,6 +18,8 @@ import sys
 import time
 import yaml
 
+__author__="nosmo@nosmo.me"
+
 # Make requests stop logging so much. I love you but you need to shut
 # up.
 requests_log = logging.getLogger("requests")
@@ -98,10 +100,22 @@ def future_fetch(edgetest, testobject_host, testobject_path,
 
 def main(dnet, dry_run, config, state_obj):
 
+    # List of edges that will be made live
+    edgelist = EdgeList()
+    edge_states = {}
+    # Object we will use to make a decision about edge liveness based
+    # on the stat stores
+    decision = DecisionMaker()
+
     # Read the edgelist as a flat file
     with open(os.path.join(config["edgelist_dir"], dnet)) as edge_f:
         edge_list = [ i.strip() for i in edge_f.read().split("\n") if i.strip() and not i.startswith("#") ]
         logging.info("Edge list is %s", str(edge_list))
+
+    # Load or create our edge state files
+    for edge in edge_list:
+        edge_state = EdgeState(edge, config["healthdata_store"], nowrite=dry_run)
+        edge_states[edge] = edge_state
 
     testobject_proto = config["testobject"]["proto"]
     testobject_host = config["testobject"]["host"]
@@ -130,9 +144,7 @@ def main(dnet, dry_run, config, state_obj):
                                                      testobject_proto,
                                                      testobject_verify))
 
-    decision = DecisionMaker()
     verification_failues = []
-    stat_stores = {}
 
     for f in as_completed(edgescore_futures):
         try:
@@ -145,19 +157,13 @@ def main(dnet, dry_run, config, state_obj):
         if value == False:
             verification_failues.append(edge)
 
-        stat_store = EdgeState(edge, config["healthdata_store"], nowrite=dry_run)
-        stat_stores[edge] = stat_store
-        stat_store.add_value(value)
+        edge_states[edge].add_value(value)
         logging.info("Fetch time for %s: %f avg: %f",
-                     edge, value, stat_store.current_average())
-        decision.add_stat_store(stat_store)
+                     edge, value, edge_states[edge].current_average())
+        decision.add_stat_store(edge_states[edge])
     threshold_stats = decision.check_threshold(config["goodenough"])
     state_obj.verification_failures = verification_failues
     logging.debug("Stats of threshold check are %s", str(threshold_stats))
-
-    # List of edges that will be made live
-
-    edgelist = EdgeList()
 
     # Do we have a previous edge list?
     still_healthy_from_last_run = check_last_live(state_obj, decision)
@@ -201,7 +207,8 @@ def main(dnet, dry_run, config, state_obj):
 
         # Note in the statefile that this edge has been put into rotation
         for live_edge in edgelist.get_live_edges():
-            stat_stores[live_edge].add_rotation()
+            edge_states[live_edge].add_rotation()
+            edge_states[live_edge].set_state("in")
 
         # Iterate over every *zone file in the zonetemplate dir and write out files.
         for zonefile in glob.glob("%s/%s/*.zone" % (config["zonetemplate_dir"], dnet)):
@@ -250,7 +257,8 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description='Manage Deflect edge status.')
     parser.add_argument("--dnet", "-A", dest="dnet", action="store",
-                        help="Specify DNET (mandatory)")
+                        help="Specify DNET",
+                        required=True)
     parser.add_argument("--config", "-c", dest="config_path", action="store",
                         help="Path to configuration file (defaults to %s)" % const.CONFIG_PATH,
                         default=const.CONFIG_PATH)
@@ -294,9 +302,6 @@ if __name__ == "__main__":
 
     logging.debug("Command line options are %s", str(args))
     logging.debug("Full configuration is:\n %s", pprint.pformat(config))
-
-    if not args.dnet:
-        raise AttributeError("DNET is a mandatory option")
 
     if not acquire_lock(config["lockfile"]):
         raise Exception("Couldn't acquire lock file - is Edgemanage running elsewhere?")

--- a/src/edge_query
+++ b/src/edge_query
@@ -68,7 +68,7 @@ def main(args):
             interested = False
 
         if edge_state.state_entry_time:
-            state_time = now - edge_state.state_entry_time
+            state_time = int(now - edge_state.state_entry_time)
         else:
             state_time = -1
 

--- a/src/edge_query
+++ b/src/edge_query
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+"""Tool for querying the state of edges.
+
+  edge_conf takes one of a number of parameters and filters, then
+ displays the corresponding edges. The behaviours of these modes can
+ be seen in edgemanage/const.py.
+
+"""
+
+__author__="nosmo@nosmo.me"
+
+from edgemanage import EdgeState
+from edgemanage.const import VALID_MODES, CONFIG_PATH
+
+import argparse
+import time
+import json
+import os
+
+import yaml
+
+def sep_output(output_tuple, verbose, quiet, output_char=" "):
+    chosen_fields = []
+    if verbose:
+        #mode state health edgename duration
+        chosen_fields = output_tuple
+    elif quiet:
+        chosen_fields = (output_tuple[3],)
+    else:
+        chosen_fields = (output_tuple[3], output_tuple[4])
+
+    print output_char.join(chosen_fields)
+
+def json_output(output_tuple, verbose, quiet):
+    # This is really dumb why just recreate a diction ah who cares
+
+    output_dict = {
+        "edge": output_tuple[3],
+    }
+    if not quiet:
+        output_dict["time_since_state_change"] = output_tuple[4]
+    if verbose:
+        output_dict["health"] = output_tuple[2]
+        output_dict["state"] = output_tuple[1]
+
+    print json.dumps(output_dict)
+
+def main(args):
+
+    with open(os.path.join(config["edgelist_dir"], args.dnet)) as edge_f:
+        edge_list = [ i.strip() for i in edge_f.read().split("\n") if i.strip() and not i.startswith("#") ]
+
+    interested_edges = []
+    output_data = []
+
+    now = time.time()
+    for edge in edge_list:
+        edge_state = EdgeState(edge, config["healthdata_store"],
+                               nowrite=True)
+
+        interested = True
+        if args.health and edge_state.health != args.health:
+            interested = False
+        if args.state and edge_state.state != args.state:
+            interested = False
+        if args.mode and edge_state.mode != args.mode:
+            interested = False
+
+        if edge_state.state_entry_time:
+            state_time = now - edge_state.state_entry_time
+        else:
+            state_time = -1
+
+        if interested:
+            output_data.append((edge_state.mode, edge_state.state,
+                                edge_state.health,
+                                edge_state.edgename,
+                                str(state_time)))
+
+    for entry in output_data:
+        if args.format == "flat":
+            sep_output(entry, args.verbose, args.quiet, " ")
+        elif args.format == "csv":
+            sep_output(entry, args.verbose, args.quiet, ",")
+        else:
+            json_output(entry, args.verbose, args.quiet)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Query Deflect edge status.')
+    parser.add_argument("--dnet", "-A", dest="dnet", action="store",
+                        help="Specify DNET", required=True)
+    parser.add_argument("--config", "-c", dest="config_path", action="store",
+                        help="Path to configuration file (defaults to %s)" % CONFIG_PATH,
+                        default=CONFIG_PATH)
+    parser.add_argument("--health", "-H", dest="health", action="store", default=None,
+                        help="Restrict output by edge health",
+                        choices=["good", "bad"])
+    parser.add_argument("--state", "-s", dest="state", action="store", default=None,
+                        help="Restrict output by edge state",
+                        choices=["out", "in"])
+    parser.add_argument("--mode", "-m", dest="mode", action="store", default=None,
+                        help="Restrict output by mode",
+                        choices=VALID_MODES)
+    parser.add_argument("--format", "-f", dest="format", action="store",
+                        help="Specify output format.", default="flat",
+                        choices=["flat", "csv", "json"])
+    parser.add_argument("--quiet", "-q", dest="quiet", action="store_true",
+                        help="List hostnames only, without details or state duration", default=False)
+    parser.add_argument("--verbose", "-v", dest="verbose", action="store_true",
+                        help=("Include full mode, state and health details for "
+                              "each matching host"), default=False)
+    args = parser.parse_args()
+
+    with open(args.config_path) as config_f:
+        config = yaml.safe_load(config_f.read())
+
+    main(args)

--- a/src/edgemanage/__init__.py
+++ b/src/edgemanage/__init__.py
@@ -1,6 +1,6 @@
 import const
 from edgetest import *
 from edgelist import EdgeList
-from statstore import StatStore
+from edgestate import EdgeState
 from decisionmaker import DecisionMaker
 from statefile import StateFile

--- a/src/edgemanage/const.py
+++ b/src/edgemanage/const.py
@@ -25,3 +25,10 @@ STATE_HISTORICAL_ROTATIONS = 100
 # Upper domain to use for looking up IP addresses of edges while
 # populating zone files
 UPPER_DOMAIN="deflect.ca"
+
+# Valid modes that an edge can be set to
+#  available - available for use normally
+#  force - force an edge into service if it's eligible
+#  blindforce - force an edge into service no matter what
+#  unavailable - never use an edge
+VALID_MODES=["available", "force", "blindforce", "unavailable"]

--- a/src/edgemanage/const.py
+++ b/src/edgemanage/const.py
@@ -1,19 +1,23 @@
+'''
+ Edgemanage constants. Not much to see here.
+'''
+
 # Default configuration path
-CONFIG_PATH="/etc/edgemanage/edgemanage.yaml"
+CONFIG_PATH = "/etc/edgemanage/edgemanage.yaml"
 # Timeout to fetch objects over HTTP
-FETCH_TIMEOUT=10
+FETCH_TIMEOUT = 10
 # Times to retry fetching an object if failed
-FETCH_RETRY=3
+FETCH_RETRY = 3
 
 # Number of objects to store in fetch histories
-FETCH_HISTORY=2000
+FETCH_HISTORY = 2000
 
 # Number of seconds that define a window within which to search for
 # fetch entries. Used in a case where we want to check the last $N
 # seconds worth of values fetched for a paritcular edge to give us a
 # more accurate average than simply averaging the last FETCH_HISTORY
 # entries.
-DECISION_SLICE_WINDOW=300
+DECISION_SLICE_WINDOW = 300
 
 # Amount of time within which to check for a rotation in order to
 # change Nagios state to WARNING.
@@ -24,11 +28,11 @@ STATE_HISTORICAL_ROTATIONS = 100
 
 # Upper domain to use for looking up IP addresses of edges while
 # populating zone files
-UPPER_DOMAIN="deflect.ca"
+UPPER_DOMAIN = "deflect.ca"
 
 # Valid modes that an edge can be set to
 #  available - available for use normally
 #  force - force an edge into service if it's eligible
 #  blindforce - force an edge into service no matter what
 #  unavailable - never use an edge
-VALID_MODES=["available", "force", "blindforce", "unavailable"]
+VALID_MODES = ["available", "force", "blindforce", "unavailable"]

--- a/src/edgemanage/decisionmaker.py
+++ b/src/edgemanage/decisionmaker.py
@@ -8,14 +8,14 @@ VALID_STATUSES = ["pass", "fail", "pass_window", "pass_average"]
 class DecisionMaker(object):
 
     def __init__(self):
-        self.stat_stores = {}
+        self.edge_states = {}
         # A results dict with edge as key, string as value, one of
         # VALID_STATUSES
         self.current_judgement = {}
 
-    def add_stat_store(self, stat_store):
-        self.stat_stores[stat_store.edgename] = stat_store
-        self.current_judgement[stat_store.edgename] = None
+    def add_edge_state(self, edge_state):
+        self.edge_states[edge_state.edgename] = edge_state
+        self.current_judgement[edge_state.edgename] = None
 
     def check_threshold(self, good_enough):
 
@@ -29,35 +29,35 @@ class DecisionMaker(object):
         for statusname in VALID_STATUSES:
             results_dict[statusname] = 0
 
-        for edgename, stat_store in self.stat_stores.iteritems():
-            time_slice = stat_store[time.time() - DECISION_SLICE_WINDOW:time.time()]
+        for edgename, edge_state in self.edge_states.iteritems():
+            time_slice = edge_state[time.time() - DECISION_SLICE_WINDOW:time.time()]
             if time_slice:
                 time_slice_avg = sum(time_slice)/len(time_slice)
                 logging.debug("Analysing %s. Last val: %f, time slice: %f, average: %f",
-                              edgename, stat_store.last_value(), time_slice_avg,
-                              stat_store.current_average())
+                              edgename, edge_state.last_value(), time_slice_avg,
+                              edge_state.current_average())
             else:
                 time_slice_avg = None
                 logging.debug("Analysing %s. Last val: %f, time slice: Not enough data, average: %f",
-                              edgename, stat_store.last_value(), stat_store.current_average())
+                              edgename, edge_state.last_value(), edge_state.current_average())
 
-            if stat_store.last_value() < good_enough:
+            if edge_state.last_value() < good_enough:
                 logging.info("PASS: Last fetch for %s is under the threshold (%f < %f)", edgename,
-                             stat_store.last_value(), good_enough)
+                             edge_state.last_value(), good_enough)
                 self.current_judgement[edgename] = "pass"
                 results_dict["pass"] += 1
             elif time_slice and time_slice_avg < good_enough:
                 self.current_judgement[edgename] = "pass_window"
                 results_dict["pass_window"] += 1
                 logging.info("UNSURE: Last fetch for %s is NOT under the threshold but the average of the last %d items is (%f < %f)", edgename, len(time_slice), time_slice_avg, good_enough)
-            elif stat_store.current_average() < good_enough:
+            elif edge_state.current_average() < good_enough:
                 results_dict["pass_average"] += 1
                 self.current_judgement[edgename] = "pass_average"
                 logging.info("UNSURE: Last fetch for %s is NOT under the threshold but under the average (%f < %f)",
-                             edgename, stat_store.current_average(), good_enough)
+                             edgename, edge_state.current_average(), good_enough)
             else:
                 results_dict["fail"] += 1
                 self.current_judgement[edgename] = "fail"
-                logging.info("FAIL: No check for %s has passed - last fetch time was %f", edgename, stat_store.last_value())
+                logging.info("FAIL: No check for %s has passed - last fetch time was %f", edgename, edge_state.last_value())
 
         return results_dict

--- a/src/edgemanage/edgelist.py
+++ b/src/edgemanage/edgelist.py
@@ -34,10 +34,16 @@ class EdgeList(object):
         return len(self.get_live_edges())
 
     def get_live_edges(self):
+        return self.get_edges_by_liveness(True)
+
+    def get_unlive_edges(self):
+        return self.get_edges_by_liveness(False)
+
+    def get_edges_by_liveness(self, islive):
         edge_list = []
         for edge, state_dict in self.edges.iteritems():
 
-            if state_dict["live"]:
+            if state_dict["live"] == islive:
                 edge_list.append(edge)
         return sorted(edge_list)
 

--- a/src/edgemanage/edgestate.py
+++ b/src/edgemanage/edgestate.py
@@ -16,6 +16,7 @@ ASSUMED_VALS={
     # A dict keyed by timestamps which keeps an average of fetch times
     # for FETCH_HISTORY days
     "historical_average": {},
+    "state": "out",
     "mode": "available",
     "health": "good",
     "state_entry_time": None,
@@ -68,14 +69,25 @@ class EdgeState(object):
         with open(self.statfile, "w") as statfile_f:
             json.dump(output, statfile_f, sort_keys=True, indent=4)
 
+    def set_state(self, state):
+        ''' Set the state of the edge - in or out '''
+        if state not in ["in", "out"]:
+            raise ValueError("State must be either in or out, not %s", state)
+        else:
+            if self.state != state:
+                self.state = state
+                self._dump()
+
     def set_mode(self, mode):
         ''' Set the mode of the edge '''
         if mode not in VALID_MODES:
             raise ValueError("Mode %s isn't in the set of valid modes (%s)",
                              mode, str(VALID_MODES))
         else:
-            self.mode = mode
-            self._dump()
+            if self.mode != mode:
+                self.state_entry_time = time.time()
+                self.mode = mode
+                self._dump()
 
     def current_average(self):
         ''' Return an average of the current live set of values '''

--- a/src/edgemanage/test_edgestate.py
+++ b/src/edgemanage/test_edgestate.py
@@ -3,19 +3,20 @@
 import unittest
 import tempfile
 
-import statstore
+import edgestate
 
 TEST_EDGE = "testedge1"
 TEST_FETCH_HISTORY = 4
-statstore.FETCH_HISTORY = TEST_FETCH_HISTORY
+# Patch edgestate's import of const
+edgestate.FETCH_HISTORY = TEST_FETCH_HISTORY
 
-class StatStoreTest(unittest.TestCase):
+class EdgeStateTest(unittest.TestCase):
 
     # TODO load test JSON file to ensure object creation
 
     def testStoreAverage(self):
         store_dir = tempfile.mkdtemp()
-        a = statstore.StatStore(TEST_EDGE, store_dir)
+        a = edgestate.EdgeState(TEST_EDGE, store_dir)
 
         for i in range(4):
             a.add_value(2)
@@ -25,7 +26,7 @@ class StatStoreTest(unittest.TestCase):
 
     def testStoreRotation(self):
         store_dir = tempfile.mkdtemp()
-        a = statstore.StatStore(TEST_EDGE, store_dir)
+        a = edgestate.EdgeState(TEST_EDGE, store_dir)
 
         for i in range(5):
             a.add_value(2)


### PR DESCRIPTION
Given that the function of the StatStore object has somewhat sprawled, it has been renamed to what it actually is - an EdgeState object. 

The EdgeState object itself has had new attributes added to it which will be migrated into existing StatStore objects. These attributes represent the fact that an edge is either in or out of rotation, its "mode" and the time that its mode last changed. 

The "mode" itself represents the state that the edge is in. At the moment const.py shows that this can be one of four states - available (ready for use as normal), unavailable (never used, out of rotation), force (always use if it's appropriate) or blindforce (always use regardless of whether it's performing poorly or even down (!!)). 

This PR introduces two new tools - edge_conf and edge_query. edge_conf is a tool for managing the configuration of edges, which allows the setting of the new mode attribute. It was decided to use a new tool for this rather than edge_manage because it is a completely different purpose, even if it *is* technically managing edges. 

Currently this PR does *not* implement the obeying of the force and blindforce modes, although it does support their setting. These will be forthcoming in another PR, but for now the unavailable functionality is seen as more important than that of the two force modes. 

:skull: :poop: :skull: :poop: :skull: :poop: :skull: :poop: :skull: :poop: 