### PR TITLE
Implement canary interface option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,39 @@ caches and so on.
 See the `edgemanage.yaml` file for documentation of the configuration
 options.
 
+Canaries
+-------
+
+So-called "canary" edges are used to assign individual network
+resources to a single zone. They are a completely optional part of
+Edgemanage configuration, but may be useful for deploying special
+configurations, per-domain systems or for detection/analysis
+approaches.
+
+An example of a use of this functionality would be if you had a number
+of systems that were present in a network environment where incoming
+traffic is filtered upstream somehow. If canaries were to be included
+for some domains with IP addresses corresponding to a system with
+unfiltered access, the canary IPs can be used for traffic capture and
+analysis without needing to discard all other hosts. This approach is
+also useful for low-cost setups where many sites are hosted and attack
+traffic such as UDP is involved. Using a per-zone IP address allows
+for a differential diagnosis of attack traffic, isolating which sites
+are attracting attacks.
+
+To give a worked example - mydnet1 has a canary file in
+```/etc/edgemanage/canaries/mydnet1```. This path is set in
+edgemanage.yaml. On run, the file in
+```/etc/edgemanage/canaries/mydnet1``` is loaded and the YAML data is
+read (it should contain only a list of site: ipaddress pairs). Let's
+say mydnet1 contains example.net: 10.0.2.22. Edgemanage
+tests 10.0.2.22 as it would any other edge but never selects it for
+what edgemanage considers to be "liveness". If
+10.0.2.22 is in a passing state, a random edge from the current live
+set is removed from example.net's configuration and 10.0.2.22 is
+added. No other zones are affected and zone files are written as
+normal.
+
 Monitoring
 --------
 

--- a/conf/edgemanage.yaml
+++ b/conf/edgemanage.yaml
@@ -87,6 +87,11 @@ named_dir: /var/cache/bind/
 # contain {dnet}
 live_list: /var/tmp/edges.{dnet}.live
 
+# Canary interfaces - see the README for an explanation of how canary
+# interfaces work. The path can contain per-dnet files, mapping domain
+# names to IP addresses.
+canary_files: /etc/edgemanage/canaries/{dnet}
+
 # Run commands before or after execution, or after a rotation/new zone
 # file being written out. A good example of a run_after_changes is
 # reloading your named, but in theory this could be anything!

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jinja2
 futures
 PyYAML
 setproctitle
+ipaddr

--- a/src/edge_manage
+++ b/src/edge_manage
@@ -105,27 +105,20 @@ def main(dnet, dry_run, config, state_obj,
 
     '''
 
-    edgemanage_object = EdgeManage(dnet, config, state, dry_run)
+    edgemanage_object = EdgeManage(dnet, config, state, canary_data, dry_run)
 
     # Read the edgelist as a flat file
     with open(os.path.join(config["edgelist_dir"], dnet)) as edge_f:
         edge_list = [ i.strip() for i in edge_f.read().split("\n") if i.strip() and not i.startswith("#") ]
         logging.info("Edge list is %s", str(edge_list))
 
-
-    if canary_data:
-        # Validate list of canary edgenames
-        bad_canaries = []
-        for canary_site, canary_ip in canary_data.iteritems():
-            try:
-                ipaddr_canary = ipaddr.IPAddress(canary_ip)
-            except ValueError as exc:
-                logging.error("Canary for %s is invalid: value %s is not an IP address",
-                              canary_site, canary_ip)
-
     # Load or create our edge state files
     for edge in edge_list:
-        edgemanage_object.add_edge_state(edge, config["healthdata_store"], nowrite=dry_run)
+        edgemanage_object.add_edge_state(edge, config["healthdata_store"],
+                                         nowrite=dry_run)
+    for canary_ip in canary_data.values():
+        edgemanage_object.add_edge_state(canary_ip, config["healthdata_store"],
+                                         nowrite=dry_run)
 
     # Run any run_before commands
     if "commands" in config and "run_before" in config["commands"]:
@@ -135,7 +128,7 @@ def main(dnet, dry_run, config, state_obj,
     verification_failues = edgemanage_object.do_edge_tests()
     state_obj.verification_failures = verification_failues
 
-    any_changes = edgemanage_object.make_edges_live(force_update, canary_data)
+    any_changes = edgemanage_object.make_edges_live(force_update)
 
     if edgemanage_object.edgelist_obj.get_live_edges() != state_obj.last_live:
         # There has been a rotation as our old list doesn't equal the new
@@ -233,6 +226,20 @@ if __name__ == "__main__":
             with open(canary_path) as canary_f:
                 canary_data = yaml.load(canary_f.read())
                 logging.debug("Canary data is %s", str(canary_data))
+
+    if canary_data:
+        # Validate list of canary edgenames
+        bad_canaries = []
+        for canary_site, canary_ip in canary_data.iteritems():
+            try:
+                ipaddr_canary = ipaddr.IPAddress(canary_ip)
+            except ValueError as exc:
+                logging.error(("Canary for %s is invalid: value %s is not an "
+                               "IP address. Not using"),
+                              canary_site, canary_ip)
+                bad_canaries.append(canary_site)
+        for bad_canary in bad_canaries:
+            del(canary_data[bad_canary])
 
     lock_f = open(config["lockfile"], "w")
 

--- a/src/edge_manage
+++ b/src/edge_manage
@@ -99,7 +99,7 @@ def main(dnet, dry_run, config, state_obj,
      dry_run: if true, no changes will be written
      state_obj: the StateFile object storing Edgemanage state for this dnet
      config: a dictionary containing the config
-     canary_data: a site-to-IP mapping. Used for canary behaviour. See docs.
+     canary_data: a site-to-canary_name map. Used for canary behaviour. See docs
      force_update: update all zone files regardless of whether we need to
 
     '''
@@ -110,6 +110,18 @@ def main(dnet, dry_run, config, state_obj,
     with open(os.path.join(config["edgelist_dir"], dnet)) as edge_f:
         edge_list = [ i.strip() for i in edge_f.read().split("\n") if i.strip() and not i.startswith("#") ]
         logging.info("Edge list is %s", str(edge_list))
+
+
+    if canary_data:
+        # Validate list of canary edgenames
+        bad_canaries = []
+        for canary_site, canary_edge in canary_data.iteritems():
+            if canary_edge not in edge_list:
+                logging.error("Canary for %s is invalid: edge %s does not exist",
+                              canary_site, canary_edge)
+                bad_canaries.add(canary_site)
+        for bad_canary_site in bad_canaries:
+            del(canary_data[bad_canary_site])
 
     # Load or create our edge state files
     for edge in edge_list:

--- a/src/edge_manage
+++ b/src/edge_manage
@@ -15,6 +15,7 @@ import sys
 import time
 import yaml
 
+import ipaddr
 import setproctitle
 
 __author__ = "nosmo@nosmo.me"
@@ -99,7 +100,7 @@ def main(dnet, dry_run, config, state_obj,
      dry_run: if true, no changes will be written
      state_obj: the StateFile object storing Edgemanage state for this dnet
      config: a dictionary containing the config
-     canary_data: a site-to-canary_name map. Used for canary behaviour. See docs
+     canary_data: a site-to-canary_ip map. Used for canary behaviour. See docs
      force_update: update all zone files regardless of whether we need to
 
     '''
@@ -115,13 +116,12 @@ def main(dnet, dry_run, config, state_obj,
     if canary_data:
         # Validate list of canary edgenames
         bad_canaries = []
-        for canary_site, canary_edge in canary_data.iteritems():
-            if canary_edge not in edge_list:
-                logging.error("Canary for %s is invalid: edge %s does not exist",
-                              canary_site, canary_edge)
-                bad_canaries.add(canary_site)
-        for bad_canary_site in bad_canaries:
-            del(canary_data[bad_canary_site])
+        for canary_site, canary_ip in canary_data.iteritems():
+            try:
+                ipaddr_canary = ipaddr.IPAddress(canary_ip)
+            except ValueError as exc:
+                logging.error("Canary for %s is invalid: value %s is not an IP address",
+                              canary_site, canary_ip)
 
     # Load or create our edge state files
     for edge in edge_list:

--- a/src/edge_manage
+++ b/src/edge_manage
@@ -89,7 +89,20 @@ def run_command_list(commands):
 
 
 
-def main(dnet, daemonise, dry_run, config, state_obj, force_update=False):
+def main(dnet, dry_run, config, state_obj,
+         canary_data={}, force_update=False):
+
+    '''
+
+    Args:
+     dnet: a string containing the dnet label to operate upon
+     dry_run: if true, no changes will be written
+     state_obj: the StateFile object storing Edgemanage state for this dnet
+     config: a dictionary containing the config
+     canary_data: a site-to-IP mapping. Used for canary behaviour. See docs.
+     force_update: update all zone files regardless of whether we need to
+
+    '''
 
     edgemanage_object = EdgeManage(dnet, config, state, dry_run)
 
@@ -110,7 +123,7 @@ def main(dnet, daemonise, dry_run, config, state_obj, force_update=False):
     verification_failues = edgemanage_object.do_edge_tests()
     state_obj.verification_failures = verification_failues
 
-    any_changes = edgemanage_object.make_edges_live(force_update)
+    any_changes = edgemanage_object.make_edges_live(force_update, canary_data)
 
     if edgemanage_object.edgelist_obj.get_live_edges() != state_obj.last_live:
         # There has been a rotation as our old list doesn't equal the new
@@ -200,6 +213,15 @@ if __name__ == "__main__":
     logging.debug("Command line options are %s", str(args))
     logging.debug("Full configuration is:\n %s", pprint.pformat(config))
 
+    canary_data = {}
+    if "canary_files" in config:
+        canary_path = config["canary_files"].format(dnet=args.dnet)
+        if os.path.isfile(canary_path):
+            logging.debug("Loading canary file from %s", canary_path)
+            with open(canary_path) as canary_f:
+                canary_data = yaml.load(canary_f.read())
+                logging.debug("Canary data is %s", str(canary_data))
+
     lock_f = open(config["lockfile"], "w")
 
     if not util.acquire_lock(lock_f):
@@ -216,10 +238,12 @@ if __name__ == "__main__":
                 daemon_setup()
 
             while True:
-                main(args.dnet, args.daemonise, args.dryrun, config, state, args.force_update)
+                main(args.dnet, args.dryrun, config,
+                     state, canary_data, args.force_update)
                 time.sleep(config["run_frequency"])
         else:
-            main(args.dnet, args.daemonise, args.dryrun, config, state, args.force_update)
+            main(args.dnet, args.dryrun, config,
+                 state, canary_data, args.force_update)
 
     state.set_last_run()
     if not args.dryrun:

--- a/src/edgemanage/edgelist.py
+++ b/src/edgemanage/edgelist.py
@@ -114,7 +114,10 @@ class EdgeList(object):
 
         if canary_edge:
             # Remove a selected edge and insert the canary edge
-            del(edge_list_to_write[random.randrange(len(edge_list_to_write))])
+            removed_edge = random.randrange(len(edge_list_to_write))
+            logging.info("Domain %s uses a canary edge of %s, removing %s",
+                         domain, canary_edge, edge_list_to_write[removed_edge])
+            del(edge_list_to_write[removed_edge])
             edge_list_to_write.append(canary_edge)
 
         #TODO cache looked up IP addresses, don't do this every time

--- a/src/edgemanage/edgelist.py
+++ b/src/edgemanage/edgelist.py
@@ -99,7 +99,7 @@ class EdgeList(object):
             return selected_edges[0]
 
     def generate_zone(self, domain, zonefile_dir, dns_config,
-                      serial_number=None):
+                      serial_number=None, canary_edge=None):
         logging.debug("Started generating zone for %s", domain)
 
         if not all([ i.endswith(".") for i in dns_config["ns_records"] ]):
@@ -110,8 +110,16 @@ class EdgeList(object):
         if "rotate_zones" in dns_config:
             rotate_zones = dns_config["rotate_zones"]
 
+        edge_list_to_write = self.get_live_edges()
+
+        if canary_edge:
+            # Remove a selected edge and insert the canary edge
+            del(edge_list_to_write[random.randrange(len(edge_list_to_write))])
+            edge_list_to_write.append(canary_edge)
+
+        #TODO cache looked up IP addresses, don't do this every time
         live_edge_ips = []
-        for live_edge in self.get_live_edges():
+        for live_edge in edge_list_to_write:
             try:
                 edge_ip = socket.gethostbyname(live_edge)
                 live_edge_ips.append(edge_ip)

--- a/src/edgemanage/edgemanage.py
+++ b/src/edgemanage/edgemanage.py
@@ -215,6 +215,10 @@ class EdgeManage(object):
 
         threshold_stats = self.decision.check_threshold(good_enough)
 
+        if self.canary_decision:
+            canary_stats = self.canary_decision.check_threshold(good_enough)
+            logging.debug("Stats of canary threshold check are %s", str(canary_stats))
+
         # Get the list of previously healthy edges
         still_healthy_from_last_run = self.check_last_live()
 
@@ -318,6 +322,7 @@ class EdgeManage(object):
                     # We have a canary edge configured, let's see if
                     # it's healthy
                     canary_ip = self.canary_data[zone_name]
+
                     canary_health = self.canary_decision.get_judgement(canary_ip)
 
                     if canary_health == "pass" or canary_health == "pass_window":

--- a/src/edgemanage/edgemanage.py
+++ b/src/edgemanage/edgemanage.py
@@ -172,7 +172,7 @@ class EdgeManage(object):
 
         Args:
          force_update: write out renewed zone files even if no changes needed
-         canary_data: per-site canary site->edge_name dict
+         canary_data: per-site canary site->canary_ip dict
 
         '''
         # Returns true if any changes were made.

--- a/src/edgemanage/edgemanage.py
+++ b/src/edgemanage/edgemanage.py
@@ -165,8 +165,16 @@ class EdgeManage(object):
 
         return list(set(still_healthy))
 
-    def make_edges_live(self, force_update):
+    def make_edges_live(self, force_update, canary_data={}):
 
+        '''
+        Choose edges, write out zone files and state info.
+
+        Args:
+         force_update: write out renewed zone files even if no changes needed
+         canary_data: per-site canary site->IP dict
+
+        '''
         # Returns true if any changes were made.
 
         good_enough = self.config["goodenough"]

--- a/src/setup.py
+++ b/src/setup.py
@@ -17,7 +17,8 @@ setup(
         "setproctitle",
         "pyyaml",
         "futures",
-        "requests"
+        "requests",
+        "ipaddr"
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
As per the updated edgemanage spec, this branch implements canary edges. This means that users can configure a canary file per-dnet. If a canary file exists, and a canary edge is specified for a domain, this edge is tested as an individual "pseudo-edge" and if suitable will be included in the edgemanage-written domains used for the specified site in place of one of the "global" live edges. 

To give a worked example - mydnet1 has a canary file in /etc/edgemanage/canaries/mydnet1. This path is set in edgemanage.yaml. On run, the file in /etc/edgemanage/canaries/mydnet1 is loaded and the YAML data is read (it should contain *only* a list of site: ipaddress pairs). Let's say mydnet1 contains ```example.net: 10.0.2.22```. Edgemanage tests 10.0.2.22 as it would any other edge but never selects it for what edgemanage considers to be "liveness". If 10.0.2.22 is in a passing state, a random edge from the current live set is removed from example.net's configuration and 10.0.2.22 is added. No other zones are affected and all zone files are written as normal. 
