### PR TITLE
Improve HTTP request performance

### DIFF
--- a/conf/edgemanage.yaml
+++ b/conf/edgemanage.yaml
@@ -45,6 +45,9 @@ edgelist_dir: /etc/edgemanage/edges/
 # performed in a 10 minute period
 dnschange_maxfreq: 10
 
+# Number of connections to make in parallel to the edges and canaries
+workers: 10
+
 # Number of retries when fetching the object from an edge
 retry: 3
 

--- a/edgemanage/edgemanage.py
+++ b/edgemanage/edgemanage.py
@@ -6,7 +6,7 @@ from .decisionmaker import DecisionMaker
 from .edgelist import EdgeList
 from .const import FETCH_TIMEOUT
 
-from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import glob
 import traceback
 import hashlib
@@ -116,7 +116,7 @@ class EdgeManage(object):
         test_verify = test_dict["verify"]
 
         edgescore_futures = []
-        with ProcessPoolExecutor() as executor:
+        with ThreadPoolExecutor(max_workers=self.config["workers"]) as executor:
             for edgename in self.edge_states:
                 edge_t = EdgeTest(edgename, self.testobject_hash)
                 edgescore_futures.append(executor.submit(future_fetch,


### PR DESCRIPTION
This PR replaces `ProcessPoolExecutor` with `ThreadPoolExecutor`.

We have been using the `ProcessPoolExecutor` for running HTTP fetches to the edges asynchronously. The `ProcessPoolExecutor` spins out each request to a different subprocess which adds a lot of extra overhead. It's meant to be used for running CPU intensive tasks on separate CPU cores.

Our HTTP requests are all IO-bound see we should be using a ThreadPoolExecutor instead. This has a much lower overhead and should be faster when starting to make requests too.

The `ProcessPoolExecutor` was also using the number of CPU's available as the number of workers. On a VM this was probably quite low and would unnecessarily limit the speed of requests.

I have now set the number of async workers to `10` and made it an option in the configuration file. This number is just a guess so we may need to tweak it up or down in the future.