### PR TITLE
Performance improvements and add a `canary_killer` threshold option

### DIFF
--- a/conf/edgemanage.yaml
+++ b/conf/edgemanage.yaml
@@ -60,6 +60,12 @@ retry: 3
 # explanation of how this value is used.
 goodenough: 0.700
 
+# All checks against the canary edges are disabled when this number of
+# edge tests have failed. All canaries for a dnet are typically run on
+# the same server. If many are down, then the whole server is probably
+# unavailable.
+canary_killer: 6
+
 # A file used to maintain state, details about last rotation and the
 # previously in-use edges. This path can and should contain {dnet}
 statefile: /var/lib/edgemanage/{dnet}.state

--- a/edgemanage/decisionmaker.py
+++ b/edgemanage/decisionmaker.py
@@ -11,6 +11,7 @@ class DecisionMaker(object):
         # A results dict with edge as key, string as value, one of
         # VALID_HEALTHS
         self.current_judgement = {}
+        self.edges_disabled = False
 
     def add_edge_state(self, edge_state):
         self.edge_states[edge_state.edgename] = edge_state
@@ -30,6 +31,14 @@ class DecisionMaker(object):
         results_dict = {}
         for statusname in const.VALID_HEALTHS:
             results_dict[statusname] = 0
+
+        # Set all as failed if this set of edges have been disabled
+        if self.edges_disabled:
+            for edgename in self.edge_states:
+                results_dict["fail"] += 1
+                self.current_judgement[edgename] = "fail"
+            logging.info("FAIL: %d edges have been disabled", results_dict["fail"])
+            return results_dict
 
         for edgename, edge_state in self.edge_states.iteritems():
             time_slice = edge_state[time.time() - const.DECISION_SLICE_WINDOW:time.time()]

--- a/edgemanage/edgemanage.py
+++ b/edgemanage/edgemanage.py
@@ -340,7 +340,14 @@ class EdgeManage(object):
                 # "we didn't break". It's horrible but it's exactly what
                 # we need here.
                 logging.error("Tried to add edges from all acceptable states but failed")
-                # TODO randomly try to add edges in a panic
+
+                # As a last option we add use the last live set of edges, even if
+                # they are unresponsive. This isn't a great option, but it's better
+                # than sending an empty set of edges to the DNS servers.
+                logging.error("Re-adding the last live edges, even though they are failing!")
+                for edgename in self.state_obj.last_live:
+                    self.edgelist_obj.add_edge(edgename, state="pass", live=True)
+                edgelist_changed = False
 
         if self.edgelist_obj.get_live_count() == required_edge_count:
             logging.info("Successfully established %d edges: %s",

--- a/tests/test_edge_manage_integration.py
+++ b/tests/test_edge_manage_integration.py
@@ -7,6 +7,7 @@ import tempfile
 import yaml
 import logging
 import pdb
+import time
 
 import pexpect
 
@@ -127,10 +128,12 @@ class EdgeManageIntegration(unittest.TestCase):
             edge_manage_command.append('--verbose')
 
         # Run and wait for command to finish
+        start_time = time.time()
         em_process = pexpect.spawn(' '.join(edge_manage_command), timeout=60)
         em_process.expect(pexpect.EOF)
         em_process.close()
         self.assertEqual(em_process.exitstatus, 0)
+        self.running_time = time.time() - start_time
 
         if debug:
             # output = '\n'.join(em_process.before.split('\r\n'))
@@ -153,6 +156,7 @@ class EdgeManageIntegration(unittest.TestCase):
         health_data = self.load_all_health_files()
         self.assertEqual(len(health_data), 40)
         self.assertTrue(all([edge['health'] == "pass" for edge in health_data.values()]))
+        self.assertLess(self.running_time, 1)
 
     def test20Edges20CanariesAll3Seconds(self):
         """
@@ -174,6 +178,7 @@ class EdgeManageIntegration(unittest.TestCase):
         # Confirm that all edges were not healthy
         health_data = self.load_all_health_files()
         self.assertTrue(all([edge['health'] == "fail" for edge in health_data.values()]))
+        self.assertLess(self.running_time, 10)
 
     def test20Edges20CanariesCanaryKiller(self):
         """
@@ -194,6 +199,7 @@ class EdgeManageIntegration(unittest.TestCase):
         failed_edges = [edge for edge in health_data.values() if edge['health'] == "fail"]
         self.assertTrue(len(health_data), 20)
         self.assertTrue(len(failed_edges), 15)
+        self.assertLess(self.running_time, 5)
 
     def tearDown(self):
         # Stop the Flask server


### PR DESCRIPTION
This pull request fixes a couple of performance issues and adds a `canary_killer` threshold to disable all canaries when many of them are failing. 

The `canary_killler` feature can be disabled by setting it to `False` in the configuration file.

This PR fixes a performance bug where the `as_completed` iterator was being run outside of the  `ThreadPoolExecutor` context manager. The context manager waits for all the schedule tasks to be completed before exiting.

As a result the `as_completed` iterator was only being run when all jobs were already completed, rather than processing jobs as they finished.

Resolves #28.
