### PR TITLE
Treat all edges under the TIMEOUT as passing

### DIFF
--- a/edgemanage/const.py
+++ b/edgemanage/const.py
@@ -39,4 +39,5 @@ VALID_MODES = ["available", "force", "blindforce", "unavailable"]
 
 # Valid states that an edge will be put into after a result of a
 # decision being passed upon tests.
-VALID_HEALTHS = ["pass", "fail", "pass_window", "pass_average"]
+VALID_HEALTHS = ["pass_threshold", "pass_window", "pass_average", "pass",
+                 "fail"]

--- a/edgemanage/decisionmaker.py
+++ b/edgemanage/decisionmaker.py
@@ -23,6 +23,9 @@ class DecisionMaker(object):
     def edge_is_passing(self, edgename):
         return self.get_judgement(edgename) != "fail"
 
+    def edge_average(self, edgename):
+        return self.edge_states[edgename].current_average()
+
     def check_threshold(self, good_enough):
 
         ''' Check fetch response times for being under the given

--- a/edgemanage/decisionmaker.py
+++ b/edgemanage/decisionmaker.py
@@ -20,6 +20,9 @@ class DecisionMaker(object):
     def get_judgement(self, edgename):
         return self.current_judgement[edgename]
 
+    def edge_is_passing(self, edgename):
+        return self.get_judgement(edgename) != "fail"
+
     def check_threshold(self, good_enough):
 
         ''' Check fetch response times for being under the given
@@ -54,32 +57,33 @@ class DecisionMaker(object):
                               edgename, edge_state.last_value(), edge_state.current_average())
 
             if edge_state.last_value() < good_enough:
-                logging.info("PASS: Last fetch for %s is under the threshold (%f < %f)", edgename,
-                             edge_state.last_value(), good_enough)
-                self.current_judgement[edgename] = "pass"
-                results_dict["pass"] += 1
-            elif edge_state.last_value() == const.FETCH_TIMEOUT:
-                results_dict["fail"] += 1
-                self.current_judgement[edgename] = "fail"
-                logging.info(("FAIL: Fetch time for %s is equal to the FETCH_TIMEOUT of %d. "
-                              "Automatic fail"),
-                             edgename, const.FETCH_TIMEOUT)
+                self.current_judgement[edgename] = "pass_threshold"
+                results_dict["pass_threshold"] += 1
+                logging.info("PASS: Last fetch for %s is under the good_enough threshold "
+                             "(%f < %f)", edgename, edge_state.last_value(), good_enough)
             elif time_slice and time_slice_avg < good_enough:
                 self.current_judgement[edgename] = "pass_window"
                 results_dict["pass_window"] += 1
-                logging.info("UNSURE: Last fetch for %s is NOT under the threshold but the "
-                             "average of the last %d items is (%f < %f)",
+                logging.info("UNSURE: Last fetch for %s is NOT under the good_enough threshold "
+                             "but the average of the last %d items is (%f < %f)",
                              edgename, len(time_slice), time_slice_avg, good_enough)
             elif edge_state.current_average() < good_enough:
-                results_dict["pass_average"] += 1
                 self.current_judgement[edgename] = "pass_average"
-                logging.info("UNSURE: Last fetch for %s is NOT under the threshold but under "
-                             "the average (%f < %f)",
+                results_dict["pass_average"] += 1
+                logging.info("UNSURE: Last fetch for %s is NOT under the good_enough threshold "
+                             "but under the average (%f < %f)",
                              edgename, edge_state.current_average(), good_enough)
+            elif edge_state.last_value() < const.FETCH_TIMEOUT:
+                self.current_judgement[edgename] = "pass"
+                results_dict["pass"] += 1
+                logging.info("PASS: Last fetch for %s is not under the good_enough threshold "
+                             "but is passing (%f < %f)", edgename,
+                             edge_state.last_value(), const.FETCH_TIMEOUT)
             else:
-                results_dict["fail"] += 1
                 self.current_judgement[edgename] = "fail"
-                logging.info("FAIL: No check for %s has passed - last fetch time was %f",
-                             edgename, edge_state.last_value())
+                results_dict["fail"] += 1
+                logging.info(("FAIL: Fetch time for %s is equal to the FETCH_TIMEOUT of %d. "
+                              "Automatic fail"),
+                             edgename, const.FETCH_TIMEOUT)
 
         return results_dict

--- a/edgemanage/edgelist.py
+++ b/edgemanage/edgelist.py
@@ -66,23 +66,6 @@ class EdgeList(object):
     def set_edge_live(self, edgename):
         self.edges[edgename]["live"] = True
 
-    def set_live_by_state(self, state, desired_count):
-
-        # return value that indicates whether we satisfied the
-        # condition of setting $desired_count hosts of $state to live
-        met_demand = False
-        edge_list = self.get_edges(state)
-        random.shuffle(edge_list)
-        for edge in edge_list:
-            if self.get_live_count() == desired_count:
-                logging.debug("Edgelist got enough (%d) edges in state %s",
-                              desired_count, state)
-                met_demand = True
-                break
-            self.set_edge_live(edge)
-
-        return met_demand
-
     def get_edges(self, state=None):
         ''' return a list of edges, with the option to filter by state '''
         if state:

--- a/tests/test_decisionmaker.py
+++ b/tests/test_decisionmaker.py
@@ -14,12 +14,17 @@ class DecisionMakerTest(EdgeStateTemplate):
 
     def _get_failing_edge_state(self):
         es = self._make_store()
-        es.add_value(GOOD_ENOUGH * 2)
+        es.add_value(edgemanage.const.FETCH_TIMEOUT)
+        return es
+
+    def _get_good_enough_edge_state(self):
+        es = self._make_store()
+        es.add_value(GOOD_ENOUGH/10)
         return es
 
     def _get_passing_edge_state(self):
         es = self._make_store()
-        es.add_value(GOOD_ENOUGH/10)
+        es.add_value(GOOD_ENOUGH*2)
         return es
 
     def _get_error_edge_state(self):
@@ -31,16 +36,28 @@ class DecisionMakerTest(EdgeStateTemplate):
         es = self._get_error_edge_state()
         dm = edgemanage.decisionmaker.DecisionMaker()
         dm.add_edge_state(es)
-        self.assertEqual(dm.check_threshold(GOOD_ENOUGH), {"fail": 1,
+        self.assertEqual(dm.check_threshold(GOOD_ENOUGH), {'fail': 1,
+                                                           'pass_threshold': 0,
                                                            'pass_window': 0,
                                                            'pass_average': 0,
                                                            'pass': 0})
 
-    def test_good_state(self):
+    def test_good_enough_state(self):
+        es = self._get_good_enough_edge_state()
+        dm = edgemanage.decisionmaker.DecisionMaker()
+        dm.add_edge_state(es)
+        self.assertEqual(dm.check_threshold(GOOD_ENOUGH), {'fail': 0,
+                                                           'pass_threshold': 1,
+                                                           'pass_window': 0,
+                                                           'pass_average': 0,
+                                                           'pass': 0})
+
+    def test_passing_state(self):
         es = self._get_passing_edge_state()
         dm = edgemanage.decisionmaker.DecisionMaker()
         dm.add_edge_state(es)
-        self.assertEqual(dm.check_threshold(GOOD_ENOUGH), {"fail": 0,
+        self.assertEqual(dm.check_threshold(GOOD_ENOUGH), {'fail': 0,
+                                                           'pass_threshold': 0,
                                                            'pass_window': 0,
                                                            'pass_average': 0,
                                                            'pass': 1})
@@ -49,7 +66,8 @@ class DecisionMakerTest(EdgeStateTemplate):
         es = self._get_failing_edge_state()
         dm = edgemanage.decisionmaker.DecisionMaker()
         dm.add_edge_state(es)
-        self.assertEqual(dm.check_threshold(GOOD_ENOUGH), {"fail": 1,
+        self.assertEqual(dm.check_threshold(GOOD_ENOUGH), {'fail': 1,
+                                                           'pass_threshold': 0,
                                                            'pass_window': 0,
                                                            'pass_average': 0,
                                                            'pass': 0})

--- a/tests/test_edge_manage_integration.py
+++ b/tests/test_edge_manage_integration.py
@@ -155,7 +155,8 @@ class EdgeManageIntegration(unittest.TestCase):
 
         health_data = self.load_all_health_files()
         self.assertEqual(len(health_data), 40)
-        self.assertTrue(all([edge['health'] == "pass" for edge in health_data.values()]))
+        self.assertTrue(all([edge['health'] == "pass_threshold"
+                             for edge in health_data.values()]))
         self.assertLess(self.running_time, 1)
 
     def test20Edges20CanariesAll3Seconds(self):

--- a/tests/test_edgelist.py
+++ b/tests/test_edgelist.py
@@ -42,15 +42,14 @@ class EdgeListTest(unittest.TestCase):
     def test_state_operations(self):
         a = edgemanage.EdgeList()
         a.add_edge("test1")
-        a.add_edge("test2", state="pass")
-        a.add_edge("test3", state="pass")
+        a.add_edge("test2", state="pass", live=True)
+        a.add_edge("test3", state="pass", live=True)
         a.add_edge("test4", state="fail")
         # invalid state - edgelist don't care.
         a.add_edge("test5", state="satan")
         a.add_edge("test6", state="pass")
 
         self.assertEqual(a.get_state_stats(), {'fail': 1, None: 1, 'satan': 1, 'pass': 3})
-        self.assertTrue(a.set_live_by_state("pass", 2))
         self.assertEqual(a.get_live_count(), 2)
         self.assertEqual(len(a.get_edges("pass")), 3)
 

--- a/tests/test_server_configs/10-edge-10-canaries-staggered.yaml
+++ b/tests/test_server_configs/10-edge-10-canaries-staggered.yaml
@@ -1,0 +1,41 @@
+edge_list:
+  1:
+    delay: 0.1
+  2:
+    delay: 0.2
+  3:
+    delay: 1
+  4:
+    delay: 2
+  5:
+    delay: 3
+  6:
+    delay: 4
+  7:
+    delay: 5
+  8:
+    delay: 6
+  9:
+    delay: 7
+  10:
+    delay: 8
+  101:
+    delay: 0.1
+  102:
+    delay: 0.2
+  103:
+    delay: 1
+  104:
+    delay: 2
+  105:
+    delay: 3
+  106:
+    delay: 4
+  107:
+    delay: 5
+  108:
+    delay: 6
+  109:
+    delay: 7
+  110:
+    delay: 8


### PR DESCRIPTION
The `good_enough` value was being used to mark an edge as "pass". All
edges with a response time greater than `good_enough` were being marked
as failing.

The correct behaviour is to mark all edges with response time less than
the `FETCH_TIMEOUT` as passing. Edges which are also less than
`good_enough` are now marked as `pass_threshold`. This will prevent
currently live edges from being rotated out when they are still fast
enough.

Redmine issue #7396.