### PR TITLE
Selected edges in order of their average response time

### DIFF
--- a/edgemanage/decisionmaker.py
+++ b/edgemanage/decisionmaker.py
@@ -23,6 +23,9 @@ class DecisionMaker(object):
     def edge_is_passing(self, edgename):
         return self.get_judgement(edgename) != "fail"
 
+    def edge_average(self, edgename):
+        return self.edge_states[edgename].current_average()
+
     def check_threshold(self, good_enough):
 
         ''' Check fetch response times for being under the given

--- a/edgemanage/edgelist.py
+++ b/edgemanage/edgelist.py
@@ -66,23 +66,6 @@ class EdgeList(object):
     def set_edge_live(self, edgename):
         self.edges[edgename]["live"] = True
 
-    def set_live_by_state(self, state, desired_count):
-
-        # return value that indicates whether we satisfied the
-        # condition of setting $desired_count hosts of $state to live
-        met_demand = False
-        edge_list = self.get_edges(state)
-        random.shuffle(edge_list)
-        for edge in edge_list:
-            if self.get_live_count() == desired_count:
-                logging.debug("Edgelist got enough (%d) edges in state %s",
-                              desired_count, state)
-                met_demand = True
-                break
-            self.set_edge_live(edge)
-
-        return met_demand
-
     def get_edges(self, state=None):
         ''' return a list of edges, with the option to filter by state '''
         if state:

--- a/tests/test_edgelist.py
+++ b/tests/test_edgelist.py
@@ -42,15 +42,14 @@ class EdgeListTest(unittest.TestCase):
     def test_state_operations(self):
         a = edgemanage.EdgeList()
         a.add_edge("test1")
-        a.add_edge("test2", state="pass")
-        a.add_edge("test3", state="pass")
+        a.add_edge("test2", state="pass", live=True)
+        a.add_edge("test3", state="pass", live=True)
         a.add_edge("test4", state="fail")
         # invalid state - edgelist don't care.
         a.add_edge("test5", state="satan")
         a.add_edge("test6", state="pass")
 
         self.assertEqual(a.get_state_stats(), {'fail': 1, None: 1, 'satan': 1, 'pass': 3})
-        self.assertTrue(a.set_live_by_state("pass", 2))
         self.assertEqual(a.get_live_count(), 2)
         self.assertEqual(len(a.get_edges("pass")), 3)
 

--- a/tests/test_server_configs/10-edge-10-canaries-staggered.yaml
+++ b/tests/test_server_configs/10-edge-10-canaries-staggered.yaml
@@ -1,0 +1,41 @@
+edge_list:
+  1:
+    delay: 0.1
+  2:
+    delay: 0.2
+  3:
+    delay: 1
+  4:
+    delay: 2
+  5:
+    delay: 3
+  6:
+    delay: 4
+  7:
+    delay: 5
+  8:
+    delay: 6
+  9:
+    delay: 7
+  10:
+    delay: 8
+  101:
+    delay: 0.1
+  102:
+    delay: 0.2
+  103:
+    delay: 1
+  104:
+    delay: 2
+  105:
+    delay: 3
+  106:
+    delay: 4
+  107:
+    delay: 5
+  108:
+    delay: 6
+  109:
+    delay: 7
+  110:
+    delay: 8


### PR DESCRIPTION
Previously extra edges which are above the good_enough would be selected randomly. This commit changes the selection code so that edges are selected in order based on minimum average response time.